### PR TITLE
Use NEXT_PUBLIC_API_URL for Replicache backend URLs

### DIFF
--- a/app/diary/atoms/ReplicacheDiaryContext.tsx
+++ b/app/diary/atoms/ReplicacheDiaryContext.tsx
@@ -74,8 +74,8 @@ export function ReplicacheDiaryProvider({ children }: { children: ReactNode }) {
     if (!rep && typeof window !== "undefined" && authToken) {
       console.log('[Replicache] Creating new Replicache instance for diary');
       
-      const pushURL = `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/push?ns=diary`;
-      const pullURL = `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/pull?ns=diary`;
+      const pushURL = `${process.env.NEXT_PUBLIC_API_URL}/replicache/push?ns=diary`;
+      const pullURL = `${process.env.NEXT_PUBLIC_API_URL}/replicache/pull?ns=diary`;
       
       const r = new Replicache<ReplicacheDiaryMutators>({
         name: "diary-replicache",
@@ -185,7 +185,7 @@ export function ReplicacheDiaryProvider({ children }: { children: ReactNode }) {
         headers['Authorization'] = `Bearer ${authToken}`;
       }
       
-      const backendUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+      const backendUrl = process.env.NEXT_PUBLIC_API_URL;
       
       try {
         await fetch(`${backendUrl}/replicache/poke-user?userId=${userId}`, { 

--- a/app/food-tracker/atoms/ReplicacheFoodContext.tsx
+++ b/app/food-tracker/atoms/ReplicacheFoodContext.tsx
@@ -92,8 +92,8 @@ export function ReplicacheFoodProvider({ children }: { children: ReactNode }) {
             await tx.del(`food/${id}`);
           },
         },
-        pushURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/push?ns=food`,
-        pullURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/pull?ns=food`,
+        pushURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/push?ns=food`,
+        pullURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/pull?ns=food`,
         auth: authToken ? `Bearer ${authToken}` : '',
         // Completely disable auto-sync
         pullInterval: null,
@@ -164,7 +164,7 @@ export function ReplicacheFoodProvider({ children }: { children: ReactNode }) {
       headers['Authorization'] = `Bearer ${authToken}`;
     }
     
-    const backendUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL;
     fetch(`${backendUrl}/replicache/poke-user?userId=${userId}`, { 
       method: 'POST',
       headers

--- a/app/ideas/atoms/ReplicacheIdeasContext.tsx
+++ b/app/ideas/atoms/ReplicacheIdeasContext.tsx
@@ -106,8 +106,8 @@ export function ReplicacheIdeasProvider({ children }: { children: ReactNode }) {
             await tx.del(`idea/${id}`);
           },
         },
-        pushURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/push?ns=ideas`,
-        pullURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/pull?ns=ideas`,
+        pushURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/push?ns=ideas`,
+        pullURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/pull?ns=ideas`,
         auth: authToken ? `Bearer ${authToken}` : '',
         // Prevent auto-sync on initialization
         pullInterval: null,
@@ -176,7 +176,7 @@ export function ReplicacheIdeasProvider({ children }: { children: ReactNode }) {
         headers['Authorization'] = `Bearer ${authToken}`;
       }
       
-      const backendUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+      const backendUrl = process.env.NEXT_PUBLIC_API_URL;
       
       try {
         await fetch(`${backendUrl}/replicache/poke-user?userId=${userId}`, { 

--- a/app/shared/ReplicacheProviders.tsx
+++ b/app/shared/ReplicacheProviders.tsx
@@ -39,7 +39,7 @@ export function SharedSSEManagerProvider({ children }: { children: ReactNode }) 
       }
     }
 
-    const backendUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL;
     if (!backendUrl) {
       console.error('[SharedSSE] No backend URL configured');
       isConnectingRef.current = false;

--- a/app/todo/atoms/ReplicacheTodoContext.tsx
+++ b/app/todo/atoms/ReplicacheTodoContext.tsx
@@ -193,8 +193,8 @@ export function ReplicacheTodoProvider({ children }: { children: ReactNode }) {
             }
           },
         },
-        pushURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/push?ns=todo`,
-        pullURL: `${process.env.NEXT_PUBLIC_BASE_API_URL}/replicache/pull?ns=todo`,
+        pushURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/push?ns=todo`,
+        pullURL: `${process.env.NEXT_PUBLIC_API_URL}/replicache/pull?ns=todo`,
         auth: authToken ? `Bearer ${authToken}` : '',
         // Keep manual control of pulls but allow immediate first pull
         pullInterval: null,
@@ -278,7 +278,7 @@ export function ReplicacheTodoProvider({ children }: { children: ReactNode }) {
         headers['Authorization'] = `Bearer ${authToken}`;
       }
       
-      const backendUrl = process.env.NEXT_PUBLIC_BASE_API_URL;
+      const backendUrl = process.env.NEXT_PUBLIC_API_URL;
       
       try {
         await fetch(`${backendUrl}/replicache/poke-user?userId=${userId}`, { 


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` for SSE and Replicache endpoints

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module; Not implemented: window.scrollTo)*

------
https://chatgpt.com/codex/tasks/task_b_68b6af1045288325867c4428b5cf1563